### PR TITLE
Keep track or rounds and client_ids

### DIFF
--- a/client/app.py
+++ b/client/app.py
@@ -31,7 +31,9 @@ def training():
                                                         request.json['epochs'],
                                                         request.json['batch_size'])
     model_params = request_params_to_model_params(training_type, request.json)
-    client.do_training(training_type, model_params, federated_learning_config)
+    round = request.json['round']
+    client_id = request.json['client_id']
+    client.do_training(training_type, model_params, federated_learning_config, round, client_id)
     return Response(status=200)
 
 

--- a/client/client.py
+++ b/client/client.py
@@ -29,6 +29,8 @@ class Client:
             print('Error: client_url is missing, cannot create a client')
             return
         self.register()
+        self.client_id = None
+        self.round = None
 
     def do_training(self, training_type, model_params, federated_learning_config):
         if self.can_do_training():
@@ -85,6 +87,11 @@ class Client:
                 print('Cannot register client in the system at', request_url, 'error:', response.reason)
             else:
                 print('Client registered successfully')
+
+                # register client id and round assigned by the server
+                response_data = response.json()
+                self.client_id = response_data['client_id']
+                self.round = response_data['round']
         except Timeout:
             print('Cannot register client in the central node, the central node is not responding')
         sys.stdout.flush()

--- a/client/client.py
+++ b/client/client.py
@@ -32,13 +32,14 @@ class Client:
         self.client_id = None
         self.round = None
 
-    def do_training(self, training_type, model_params, federated_learning_config):
+    def do_training(self, training_type, model_params, federated_learning_config, round, client_id):
         if self.can_do_training():
             self.training_type = training_type
-            print(federated_learning_config)
+            self.round = round
+            self.client_id = client_id
 
             if self.training_type == TrainingType.MNIST:
-                client_model_trainer = MnistModelTrainer(model_params, federated_learning_config)
+                client_model_trainer = MnistModelTrainer(model_params, federated_learning_config, self.client_id, self.round)
             elif self.training_type == TrainingType.CHEST_X_RAY_PNEUMONIA:
                 client_model_trainer = ChestXRayModelTrainer(model_params, federated_learning_config)
             else:

--- a/client/mnist_model_trainer.py
+++ b/client/mnist_model_trainer.py
@@ -4,13 +4,15 @@ from .training_utils import mnist_loss, linear_model
 
 
 class MnistModelTrainer:
-    def __init__(self, model_params, client_config):
+    def __init__(self, model_params, client_config, client_id, round):
         print('Initializing MnistModelTrainer...')
         self.ACCURACY_THRESHOLD = 0.5
         self.training_dataloader = None
         self.validation_dataloader = None
         self.client_config = client_config
         self.model_params = model_params
+        self.round = round
+        self.client_id = client_id
 
     def train_model(self):
         training_dataset, validation_dataset = self.__load_datasets()
@@ -45,6 +47,8 @@ class MnistModelTrainer:
         return corrections.float().mean()
 
     def __load_datasets(self):
+        print('HIII', self.client_id)
+        print("POO", self.round)
         print('Loading dataset MNIST_SAMPLE...')
         path = untar_data(URLs.MNIST_SAMPLE)
         print('Content of MNIST_SAMPLE:', path.ls())

--- a/client/mnist_model_trainer.py
+++ b/client/mnist_model_trainer.py
@@ -47,15 +47,19 @@ class MnistModelTrainer:
         return corrections.float().mean()
 
     def __load_datasets(self):
-        print('HIII', self.client_id)
-        print("POO", self.round)
         print('Loading dataset MNIST_SAMPLE...')
         path = untar_data(URLs.MNIST_SAMPLE)
         print('Content of MNIST_SAMPLE:', path.ls())
         print("Content of 'train' directory of MNIST_SAMPLE", (path / 'train').ls())
 
-        threes = random.sample((path / 'train' / '3').ls().sorted(), int(random.uniform(20, 30)))
-        sevens = random.sample((path / 'train' / '7').ls().sorted(), int(random.uniform(20, 30)))
+        client_id = int(self.client_id)
+        round = int(self.round)
+        train_sample_size = 25
+        max_client_number = 5
+        start_index = train_sample_size * client_id + (round - 1) * train_sample_size * max_client_number
+        end_index = start_index + train_sample_size
+        threes = (path / 'train' / '3').ls().sorted()[start_index:end_index]
+        sevens = (path / 'train' / '7').ls().sorted()[start_index:end_index]
 
         three_tensors = [tensor(Image.open(image_path)) for image_path in threes]
         seven_tensors = [tensor(Image.open(image_path)) for image_path in sevens]
@@ -65,8 +69,11 @@ class MnistModelTrainer:
         stacked_threes = torch.stack(three_tensors).float() / 255
         stacked_sevens = torch.stack(seven_tensors).float() / 255
 
-        valid_three_paths = random.sample((path / 'valid' / '3').ls(), int(random.uniform(10, 20)))
-        valid_seven_paths = random.sample((path / 'valid' / '7').ls(), int(random.uniform(10, 20)))
+        valid_sample_size = 15
+        valid_start_index = valid_sample_size * client_id + (round - 1) * valid_sample_size * max_client_number
+        valid_end_index = start_index + valid_sample_size
+        valid_three_paths = (path / 'valid' / '3').ls().sorted()[valid_start_index:valid_end_index]
+        valid_seven_paths = (path / 'valid' / '7').ls()[valid_start_index:valid_end_index]
 
         valid_three_tensors = torch.stack([tensor(Image.open(valid_three_path)) for valid_three_path in valid_three_paths])
         valid_three_tensors = valid_three_tensors.float() / 255

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -2,7 +2,7 @@ import asyncio
 import os
 
 from flask import (
-    Flask, Response, request, render_template
+    Flask, Response, request, render_template, jsonify
 )
 
 from .server import Server
@@ -42,8 +42,11 @@ def create_app(test_config=None):
     @app.route('/client', methods=['POST'])
     def register_client():
         print('Request POST /client for client_url [', request.form['client_url'], ']')
-        server.register_client(request.form['client_url'])
-        return Response(status=201)
+        client_id, round = server.register_client(request.form['client_url'])
+        data_dict = {'client_id': client_id, 'round': round}
+        response = jsonify(data_dict)
+        response.status_code = 201
+        return response
 
     @app.route('/client', methods=['DELETE'])
     def unregister_client():

--- a/server/server.py
+++ b/server/server.py
@@ -20,6 +20,7 @@ class Server:
         self.init_params()
         self.training_clients = {}
         self.status = ServerStatus.IDLE
+        self.round = 0
 
     def init_params(self):
         if self.mnist_model_params is None:
@@ -114,8 +115,10 @@ class Server:
     def register_client(self, client_url):
         print('Registering new training client [', client_url, ']')
         if self.training_clients.get(client_url) is None:
-            self.training_clients[client_url] = TrainingClient(client_url)
+            next_client_id = len(self.training_clients) + 1
+            self.training_clients[client_url] = TrainingClient(client_url, next_client_id)
             print('Client [', client_url, '] registered successfully')
+            return next_client_id, self.round
         else:
             print('Client [', client_url, '] was already registered in the system')
             self.training_clients.get(client_url).status = ClientTrainingStatus.IDLE

--- a/server/training_client.py
+++ b/server/training_client.py
@@ -2,10 +2,12 @@ from .client_training_status import ClientTrainingStatus
 
 
 class TrainingClient:
-    def __init__(self, client_url):
+    def __init__(self, client_url, client_id):
         self.client_url = client_url
         self.status = ClientTrainingStatus.IDLE
         self.model_params = None
+        self.client_id = client_id
+
 
     def __str__(self):
         return "Training client:\n--Client URL: {}\n--Status: {}\n".format(


### PR DESCRIPTION
This PR updates the data selection for testing and validation to avoid reusing samples across clients. Additionally, it also prevents sample reuse across training rounds.

There's a bug where client_id get overwritten by the last known client id in MNIST model trainer. I will fix it in the next PR.